### PR TITLE
fix startup install issue

### DIFF
--- a/install.py
+++ b/install.py
@@ -2,9 +2,10 @@ import os
 import launch
 import platform
 import subprocess
-from scripts.util import check_aria2c
+import importlib  
+mdc = importlib.import_module("scripts.model-downloader-cn")
 
-has_aria2c = check_aria2c()
+has_aria2c = mdc.check_aria2c()
 
 if platform.system() == "Linux":
     if not has_aria2c:


### PR DESCRIPTION
Current start with error like following:

```sh
Error running install.py for extension C:\...\extensions\sd-webui-model-downloader-cn.
Command: "C:\...\python\python.exe" "C:\...\extensions\sd-webui-model-downloader-cn\install.py"
Error code: 1
stderr: Traceback (most recent call last):
  File "C:\...\extensions\sd-webui-model-downloader-cn\install.py", line 5, in <module>
    from scripts.util import check_aria2c
ModuleNotFoundError: No module named 'scripts.util'
```

Fixed with this PR.