### PR TITLE
修复了预览的Bug，增加了视频封面的预览能力

### DIFF
--- a/scripts/model-downloader-cn.py
+++ b/scripts/model-downloader-cn.py
@@ -1,13 +1,15 @@
 import modules.scripts as scripts
 from modules.paths_internal import models_path, data_path
 from modules import script_callbacks, shared
-from PIL import Image
+from PIL import Image,ImageDraw,ImageFont
 import numpy as np
 import gradio as gr
 import requests
 import os
 import re
 import subprocess
+import cv2
+import tempfile
 import threading
 
 
@@ -24,8 +26,7 @@ def check_aria2c():
     except FileNotFoundError:
         return False
 
-def process_image(url):
-    response = requests.get(url, stream=True)
+def process_image(response):
     image = Image.open(response.raw)
     return image
 
@@ -72,17 +73,59 @@ def request_civitai_detail(url):
     else:
         return False, res.text
 
+def fail_image():
+    img = Image.new('RGB', size=(256, 384), color=(222, 222, 255))
+    draw = ImageDraw.Draw(img)
+    draw.text((45, 120), "Load Preview Image Fail", font=ImageFont.truetype("arial.ttf", 15), fill=(255, 0, 0))
+    return img
+
+def extract_image(response):
+    # 使用OpenCV读取视频
+    with tempfile.NamedTemporaryFile() as temp:
+        temp.write(response.content)
+        cap = cv2.VideoCapture(temp.name)
+        # 检查cap是否为None
+        if cap is None:
+            print("Failed to decode image.")
+            return fail_image()
+
+        # 读取一帧
+        ret, frame = cap.read()
+        # 如果正确读取帧，ret为True
+        if not ret:
+            print("Can't receive frame (stream end?). Exiting ...")
+            return fail_image()
+
+        # 将BGR帧转换为RGB帧，因为PIL使用RGB格式
+        frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+
+        # 使用PIL保存帧为图片
+        image = Image.fromarray(frame)
+        # 释放视频对象
+        cap.release()
+
+        return image
+
 def resp_to_components(resp):
     if resp is None:
         return [None, None, None, None, None, None, None, None, None, None]
 
-    img = resp["version"]["image"]["url"]
-    if img:
-        img = process_image(img)
+    image_type = resp["version"]["image"]["type"]
+    img_url = resp["version"]["image"]["url"]
+    response = requests.get(img_url, stream=True)
+    try:
+        if image_type == "video":
+            img = extract_image(response)
+        else:
+            img = process_image(response)
+    except Exception as e:
+        print("加载预览图出错：" + e.__cause__)
+        img = fail_image()
+
 
     trained_words = resp["version"].get("trainedWords", [])
     if not trained_words:
-        trained_words = ["girl"]
+        trained_words = ["N/A"]
 
     trained_words_str = ", ".join(trained_words)
     updated_at = resp["version"].get("updatedAt", "N/A")
@@ -100,25 +143,57 @@ def resp_to_components(resp):
         resp["version"]["file"]["downloadUrl"],
     ]
 
-
 def preview(url):
     ok, resp = request_civitai_detail(url)
     if not ok:
         return [resp] + resp_to_components(None) + [gr.update(interactive=False)]
-
     has_download_file = False
     more_guides = ""
-    if resp["version"]["file"]["downloadUrl"]:
+    target_url = resp["version"]["file"]["downloadUrl"]
+    if target_url:
         has_download_file = True
-        more_guides = f'，点击下载按钮\n{resp["version"]["file"]["name"]}'
+        more_guides = f'，点击下载按钮\n{resp["version"]["file"]["name"]}\n'
 
+    try:
+        filename=resp["version"]["file"]["name"]
+        model_type = resp["type"]
+        target_path = get_model_path(model_type)
+        target_file = os.path.join(target_path, filename)
 
-    return [f"预览成功{more_guides}"] + resp_to_components(resp) + \
-            [gr.update(interactive=has_download_file)]
+        curl = f'curl -o "{target_file}" "{target_url}" 2>&1'
+        aria2c = f'aria2c -c -x 16 -s 16 -k 1M -d "{target_path}" -o "{filename}" "{target_url}" 2>&1'
 
+        download_cmd = f"""\n模型下载地址：\n{target_url}\n\n下载命令：\n{curl}\n\n{aria2c}"""
 
-def download(model_type, filename, url, image_arr):
-    if not (model_type and url and filename):
+        result = [f"预览成功{more_guides}{download_cmd}"] + resp_to_components(resp) + [gr.update(interactive=has_download_file)] + [gr.update(interactive=has_download_file)]
+    except Exception as e:
+        print("图片预览失败" + e.args)
+    return result
+
+def download_image(model_type, filename, target_url, image_arr):
+    if not (model_type and target_url and filename):
+        return "下载信息缺失"
+
+    target_path = get_model_path(model_type)
+
+    status_output=""
+    if isinstance(image_arr, np.ndarray) and image_arr.any() is not None:
+        image_filename = filename.rsplit(".", 1)[0] + ".jpeg"
+        target_file = os.path.join(target_path, image_filename)
+        if not os.path.exists(target_file):
+            image = Image.fromarray(image_arr)
+            image.save(target_file)
+            status_output = "图片下载完成\n"
+        else:
+            status_output = f"已经存在了，不重复下载：\n{target_file}\n"
+
+    curl = f'curl -o "{target_file}" "{target_url}" 2>&1'
+    aria2c = f'aria2c -c -x 16 -s 16 -k 1M -d "{target_path}" -o "{filename}" "{target_url}" 2>&1'
+
+    return status_output + f"""\n模型下载地址：\n{target_url}\n\n下载命令：\n{curl}\n\n{aria2c}"""
+
+def download(model_type, filename, target_url, image_arr):
+    if not (model_type and target_url and filename):
         return "下载信息缺失"
 
     target_path = get_model_path(model_type)
@@ -137,9 +212,9 @@ def download(model_type, filename, url, image_arr):
         return f"已经存在了，不重复下载：\n{target_file}"
 
 
-    cmd = f'curl -o "{target_file}" "{url}" 2>&1'
+    cmd = f'curl -o "{target_file}" "{target_url}" 2>&1'
     if check_aria2c():
-        cmd = f'aria2c -c -x 16 -s 16 -k 1M -d "{target_path}" -o "{filename}" "{url}" 2>&1'
+        cmd = f'aria2c -c -x 16 -s 16 -k 1M -d "{target_path}" -o "{filename}" "{target_url}" 2>&1'
 
     result = subprocess.run(
         cmd,
@@ -155,7 +230,6 @@ def download(model_type, filename, url, image_arr):
         status_output = f"下载失败了，错误信息：\n{result.stdout}"
 
     return status_output
-
 
 def request_online_docs():
     banner = "## 加载失败，可以更新插件试试：\nhttps://github.com/tzwm/sd-webui-model-downloader-cn"
@@ -188,6 +262,7 @@ def on_ui_tabs():
                 )
                 with gr.Row():
                     preview_btn = gr.Button("预览")
+                    download_image_btn = gr.Button("下载预览图片", interactive=False)
                     download_btn = gr.Button("下载", interactive=False)
                 with gr.Row():
                     result = gr.Textbox(
@@ -249,14 +324,18 @@ def on_ui_tabs():
             fn=preview,
             inputs=[inp_url],
             outputs=[result] + preview_components() + \
-                file_info_components() + [download_btn]
+                file_info_components() + [download_image_btn] + [download_btn]
+        )
+        download_image_btn.click(
+            fn=download_image,
+            inputs=[model_type] + file_info_components() + [image],
+            outputs=[result]
         )
         download_btn.click(
             fn=download,
             inputs=[model_type] + file_info_components() + [image],
             outputs=[result]
         )
-
     return [(ui_component, "模型下载", "model_downloader_cn_tab")]
 
 script_callbacks.on_ui_tabs(on_ui_tabs)

--- a/scripts/model-downloader-cn.py
+++ b/scripts/model-downloader-cn.py
@@ -73,20 +73,27 @@ def request_civitai_detail(url):
         return False, res.text
 
 def resp_to_components(resp):
-    if resp == None:
+    if resp is None:
         return [None, None, None, None, None, None, None, None, None, None]
 
     img = resp["version"]["image"]["url"]
     if img:
         img = process_image(img)
 
+    trained_words = resp["version"].get("trainedWords", [])
+    if not trained_words:
+        trained_words = ["girl"]
+
+    trained_words_str = ", ".join(trained_words)
+    updated_at = resp["version"].get("updatedAt", "N/A")
+
     return [
         resp["name"],
         resp["type"],
-        ", ".join(resp["version"]["trainedWords"]),
+        trained_words_str,
         resp["creator"]["username"],
         ", ".join(resp["tags"]),
-        resp["version"]["updatedAt"],
+        updated_at,
         resp["description"],
         img,
         resp["version"]["file"]["name"],


### PR DESCRIPTION
- 修复 预览逻辑返回数据的取值Bug
- 增加 视频封面的首帧预览图
- 增加 预览时 将下载命令返回到页面，供用户复制后自执行
- 增加 仅下载预览图按钮（因为当前还没有进度条，适合喜欢自己到服务端执行下载模型命令的用户）